### PR TITLE
Added background color on code tag

### DIFF
--- a/source/css/custom.css
+++ b/source/css/custom.css
@@ -169,14 +169,14 @@ img {
   border-radius: 50%;
 }
 
-li p code {
+code:not(pre code) {
   background-color: rgb(230, 230, 230);
   border-radius: 5px;
   padding: 0px 2px;
   font-size: 85%;
 }
 
-body.darkmode li p code {
+body.darkmode code:not(pre code) {
   background-color: rgb(65, 65, 65);
 }
 


### PR DESCRIPTION
Added background color when the code tag is not wrapped in `li`. I think the style on the code tag looks awesome but it only appears when it's wrapped in `li` so I try to add this.

Here is the preview

Berfore:
<img width="449" alt="before" src="https://user-images.githubusercontent.com/67775387/161001775-39bcff61-c7c5-4bd4-8fa7-ff91b9192201.png">

After:
<img width="458" alt="after" src="https://user-images.githubusercontent.com/67775387/161001810-96a15a36-81ca-404a-9a29-d899502980e3.png">


