### PR TITLE
Make search block only appear on home page

### DIFF
--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -26,5 +26,6 @@
   </div>
 </div>
 <% }) %>
-
 <h4> <a href="<%= config.root %>archives">All Posts</a></h4>
+
+<%- partial('partial/search') %>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -120,6 +120,8 @@
   <script src="<%- theme.picjs %>" defer></script>
   <% } %>
 
+  <!-- Search
+  –––––––––––––––––––––––––––––––––––––––––––––––––– -->
   <% if(config.search){ %>
   <script src="/js/search.min.js" defer></script>
   <% } %>
@@ -135,7 +137,6 @@
         <div class="trans">
           <%- body %>
         </div>
-        <%- partial('partial/search') %>
         <%- partial('partial/footer') %>
       </div>
 


### PR DESCRIPTION
Search box will appear on every page by default. Change it to appear only on the home page.